### PR TITLE
cs - implement zip code controller with test

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,38 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+@Api(description="Zip Code Information from http://www.zippopotam.us/")
+@Slf4j
 @RestController
+@RequestMapping("/api/zipcode")
 public class ZipCodeController {
-    
+
+    @Autowired
+    ZipCodeQueryService zipCodeQueryService;
+
+    @ApiOperation(value="Get information about a us zipcode", notes="")
+    @GetMapping("/get")
+    public ResponseEntity<String> getCountryCodes(
+        @ApiParam("US zipcode, e.g. 93106") @RequestParam String zipcode
+    ) throws JsonProcessingException {
+        log.info("getZipCodes: zipcode={}", zipcode);
+        String result = zipCodeQueryService.getJSON(zipcode);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value=ZipCodeController.class)
+public class ZipCodeControllerTests {
+	
+	@Autowired
+	private MockMvc mockMvc;
+	@MockBean
+	ZipCodeQueryService mockZipCodeQueryService;
+
+	@Test
+	public void test_getZipCodes() throws Exception {
+
+		String fakeJsonResult="{ \"fake\" : \"result\" }";
+		String zipcode = "93117";
+		when(mockZipCodeQueryService.getJSON(eq(zipcode))).thenReturn(fakeJsonResult);
+
+		String url = String.format("/api/zipcode/get?zipcode=%s", zipcode);
+
+		MvcResult response = mockMvc
+			.perform( get(url).contentType("application/json"))
+			.andExpect(status().isOk()).andReturn();
+
+		String responseString = response.getResponse().getContentAsString();
+
+		assertEquals(fakeJsonResult, responseString);
+	}
+}


### PR DESCRIPTION
In this PR, we add an endpoint "/api/zipcode/get" that's used to get information about the location of a zipcode.